### PR TITLE
ci: fix workflows for release

### DIFF
--- a/.github/workflows/on-pull-request-close.yml
+++ b/.github/workflows/on-pull-request-close.yml
@@ -3,11 +3,11 @@ on:
     types: [closed]
 
 jobs:
-  delete_from_r2:
-    name: Delete PDF from r2
+  delete_from_api:
+    name: Delete PDF from api.ajr.dev
     runs-on: ubuntu-latest
     steps:
-      - id: delete_assets_r2
+      - name: Delete asset from api.ajr.dev
         env:
           API_KEY: ${{ secrets.API_KEY }}
           URL: https://api.ajr.dev/files/austin-rovge-resume-draft-${{ github.event.number }}.pdf

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -23,7 +23,6 @@ jobs:
         body: |
             Building new PDF for commit ${{ github.event.pull_request.head.sha }}
   build:
-    name: Build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -34,19 +33,7 @@ jobs:
       - name: Make
         run: |
           make all
-      - uses: actions/upload-artifact@v3
-        with:
-          name: resume
-          path: austin-rovge-resume.pdf
-  upload_draft_pdf_to_r2:
-    name: Upload draft PDF
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: resume
-      - id: upload_assets_r2
+      - name: Upload asset to api.ajr.dev
         env:
           API_KEY: ${{ secrets.API_KEY }}
           URL: https://api.ajr.dev/files/austin-rovge-resume-draft-${{ github.event.number }}.pdf
@@ -54,7 +41,7 @@ jobs:
           curl $URL -s -o /dev/null -f -X PUT -H 'X-API-Key: '$API_KEY'' -H 'Content-Type: document' --data-binary @austin-rovge-resume.pdf
   link_pdf_to_pr_comment:
     name: Link PDF to PR comment
-    needs: upload_draft_pdf_to_r2
+    needs: build
     runs-on: ubuntu-latest
     steps:
     - name: Find existing comment

--- a/.github/workflows/on-push-main.yml
+++ b/.github/workflows/on-push-main.yml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   build:
-    name: Build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -17,37 +17,21 @@ jobs:
       - name: Make
         run: |
           make all
-      - uses: actions/upload-artifact@v3
-        with:
-          name: resume
-          path: austin-rovge-resume.pdf
-  upload:
-    name: Upload
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - id: create_release
-        uses: actions/create-release@v1
+      - name: Get release
+        id: get_release
+        uses: bruceadams/get-release@v1.3.2
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: false
-      - uses: actions/download-artifact@v3
-        with:
-          name: resume
-      - id: upload_assets_release
+          GITHUB_TOKEN: ${{ github.token }}
+      - name: Upload release asset to GitHub
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
           asset_path: ./austin-rovge-resume.pdf
           asset_name: austin-rovge-resume.pdf
           asset_content_type: application/pdf
-      - id: upload_assets_r2
+      - name: Upload release asset to api.ajr.dev
         env:
           API_KEY: ${{ secrets.API_KEY }}
         run: |


### PR DESCRIPTION
This cleans up the workflows a bit and fixes issues with deploying now that I rely on GitHub creating the release instead of doing it myself