### PR TITLE
ci: fix whitespace in workflows

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -1,4 +1,3 @@
-name: Build
 on:
   pull_request
 
@@ -7,21 +6,21 @@ jobs:
     name: Add building comment
     runs-on: ubuntu-latest
     steps:
-    - name: Find existing comment
-      uses: peter-evans/find-comment@v2
-      id: find_comment
-      with:
-        issue-number: ${{ github.event.number }}
-        comment-author: 'github-actions[bot]'
-    - name: Update/add comment with remote link
-      uses: peter-evans/create-or-update-comment@v2
-      continue-on-error: true
-      with:
-        comment-id: ${{ steps.find_comment.outputs.comment-id }}
-        issue-number: ${{ github.event.number }}
-        edit-mode: replace
-        body: |
-            Building new PDF for commit ${{ github.event.pull_request.head.sha }}
+      - name: Find existing comment
+        uses: peter-evans/find-comment@v2
+        id: find_comment
+        with:
+          issue-number: ${{ github.event.number }}
+          comment-author: 'github-actions[bot]'
+      - name: Update/add comment with remote link
+        uses: peter-evans/create-or-update-comment@v2
+        continue-on-error: true
+        with:
+          comment-id: ${{ steps.find_comment.outputs.comment-id }}
+          issue-number: ${{ github.event.number }}
+          edit-mode: replace
+          body: |
+              Building new PDF for commit ${{ github.event.pull_request.head.sha }}
   build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/on-push-main.yml
+++ b/.github/workflows/on-push-main.yml
@@ -1,4 +1,3 @@
-name: Build
 on:
   push:
     branches:

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -15,18 +15,18 @@ jobs:
       - name: Make
         run: |
           make all
-     - uses: actions/upload-artifact@v3
-         with:
-           name: resume
-           path: austin-rovge-resume.pdf
+      - uses: actions/upload-artifact@v3
+        with:
+          name: resume
+          path: austin-rovge-resume.pdf
   upload:
     name: Upload release assets to GitHub/api.ajr.dev
     runs-on: ubuntu-latest
     needs: build
     steps:
       - uses: actions/download-artifact@v3
-         with:
-           name: resume
+        with:
+          name: resume
       - name: Get release
         id: get_release
         uses: bruceadams/get-release@v1.3.2


### PR DESCRIPTION
This caused a CI failure on master when it attempted to run the on-tag workflow

Airing of grievances:

GitHub doesn't validate all workflow files as part of MR status checks? A whitespace issue in yaml can cause this? Brilliant