### PR TITLE
2023 refresh

### DIFF
--- a/experience.tex
+++ b/experience.tex
@@ -1,6 +1,7 @@
 \section{EXPERIENCE}
 \begin{tabular*}{\textwidth}{l@{\extracolsep{\fill}}r}
-  Software Engineer & June 2021 – Present\\
+  Senior Software Engineer & March 2024 – Present\\
+  Software Engineer & June 2021 – March 2024 \\
   Software Engineer Intern & June 2019 – June 2021\\
   Direct Supply & Milwaukee, WI\\
 \end{tabular*}

--- a/experience.tex
+++ b/experience.tex
@@ -12,7 +12,7 @@
         Containerized legacy C\# applications to run in serverless AWS Fargate, moved secrets to HashiCorp Vault, and created infrastructure to route traffic securely between Route53, ALB, and the ECS cluster, resulting in lowered maintenance costs and more resilient error handling.
     }
     \item{
-        Researched and introduced Swift structured concurrency to the iOS app, reducing the 90-day crash rate by 50\% from \textasciitilde2,200 crashes to \textasciitilde800 crashes, improving user experience and app stability.
+        Researched and introduced Swift structured concurrency to the iOS app, reducing the 90-day crash rate by \textasciitilde85\% from \textasciitilde2,200 crashes to \textasciitilde320 crashes, improving user experience and app stability.
     }
 \end{bulletlist}
 


### PR DESCRIPTION
- [ ] Experience: Add user metrics to provide crash count context
- [ ] Experience: 1st and 3rd bullet are the same. Combine into one bullet
- [ ] Experience: Either add more technology or emphasize more senior-ey things
- [ ] Mentorship/Projects: Add an end date for FRC mentor
- [ ] Mentorship/Projects: Consider removing FRC mentor now that I am no longer one
- [ ] Mentorship/Projects: Consider section rename to "Projects" if FRC mentor is removed
- [ ] Mentorship/Projects: Consider removing the fluoroscopy sim
    - My other projects need more investment before I could add them to this. ex: flix, foodie, memories, shaba-lang
- [ ] Education: Consider removing GPA (but then minor is on it's own line unless removed so why not include it anyway? unless uni location is replaced with minor or it's added next to BS)